### PR TITLE
Add license and basic API tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nexus-Pilot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ temperature: float (optional)
 
 ---
 
+
+## Testing
+
+Install dependencies and run the tests using `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/api.py
+++ b/api.py
@@ -1,14 +1,25 @@
-nexus-pilot/
-├── api/
-│   └── api.py
-├── logic/
-│   └── prompt_chainer.py
-├── prompts/
-│   ├── base.txt
-│   ├── suggestion.txt
-│   └── meta_eval.txt
+from typing import List
+from fastapi import FastAPI
+from pydantic import BaseModel
 
-├── Dockerfile
-├── README.md
-├── requirements.txt
-└── LICENSE
+app = FastAPI()
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: List[Message]
+    temperature: float = 1.0
+
+class ChatChoice(BaseModel):
+    message: Message
+
+class ChatResponse(BaseModel):
+    choices: List[ChatChoice]
+
+@app.post("/v1/chat/completions", response_model=ChatResponse)
+def chat_completions(req: ChatRequest) -> ChatResponse:
+    reply = Message(role="assistant", content="This is a placeholder response.")
+    return ChatResponse(choices=[ChatChoice(message=reply)])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from api import app
+
+client = TestClient(app)
+
+def test_chat_completions_returns_response():
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "nexus-pilot",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.5,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "choices" in data
+    assert data["choices"][0]["message"]["role"] == "assistant"


### PR DESCRIPTION
## Summary
- add MIT license
- implement placeholder FastAPI app
- include test using FastAPI TestClient
- document running tests in README
- add minimal requirements list

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6857f18b93c08325b8d1fb6a69853299